### PR TITLE
Update example to use defn instead of def

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@ Specify your vector to define your map, then process it with =(render-applicatio
 
 *** Example form-structure
 #+BEGIN_SRC clojure
-(def test-form [:mytext {:type :text
+(defn test-form [] [:mytext {:type :text
                          :label "My text"}
                 :mytextarea {:type :textarea
                              :label "My textarea"}
@@ -44,7 +44,7 @@ Specify your vector to define your map, then process it with =(render-applicatio
 As the second arg to =render-application= you can specify your read and update functions, which will be called to get the value of a field and to update the value of a field. Each function will receive from Reformation =[:path :to :value]= and, for update, also =new-value=. The following example works if you are using a local atom; you can trivially adjust this function to work with re-frame. 
 
 #+BEGIN_SRC clojure
-(rfc/render-application test-form {:READ (partial get-in @my-atom)
+(rfc/render-application (test-form) {:READ (partial get-in @my-atom)
                                    :UPDATE (partial swap! my-atom update-in)})
 #+END_SRC
 


### PR DESCRIPTION
Using def makes the data structure be compiled only once, which is fine if the vals aren't changing within the structure, but if they are, calling a `reframe/subscribe` on a value to be inserted into the table-structure causes it to fail, as the value is updated more than once. See https://stackoverflow.com/questions/4461320/clojure-def-vs-defn-for-a-function-with-no-arguments. The following is an example that uses defn correctly for Reformation. 
```
(defn test-form []
  (let [default-vals (rfc/subscribe [:get-edit-form :devices])]
    [:devices [:edit
               [:myhidden-text {:type :hidden
                                :default-value "whisper"}
                :model {:type :text
                        :default-value (:model @default-vals)
                        :required? true
                        :style-classes "has-text-centered"
                        :label "Model"}]]]))